### PR TITLE
Implement random item drop system for enemies

### DIFF
--- a/Assets/Materials/Exp.mat
+++ b/Assets/Materials/Exp.mat
@@ -1,0 +1,136 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Exp
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0.8144999, b: 0.0141509175, a: 1}
+    - _Color: {r: 1, g: 0.8144999, b: 0.0141509175, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
+--- !u!114 &1115011630405678447
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9

--- a/Assets/Materials/Exp.mat.meta
+++ b/Assets/Materials/Exp.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f91dd63938c6f740abfe84b0a06d07a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BombDrop.prefab
+++ b/Assets/Prefabs/BombDrop.prefab
@@ -1,0 +1,180 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &8533705008016051139
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42.396145
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.814128
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.30869
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 580d7e954bbff174794836248c2cc077, type: 2}
+    - target: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_Name
+      value: BombDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8374049007802197439}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7473638909329927306}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8257979677404303858}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5255270958456016188}
+  m_SourcePrefab: {fileID: 100100000, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+--- !u!1 &8839623426836133522 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b69ab7dc4a09f094885bf950a65c44c3, type: 3}
+  m_PrefabInstance: {fileID: 8533705008016051139}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &8374049007802197439
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839623426836133522}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.96000195
+  m_Height: 2.4438257
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.24871472, z: -0.006569177}
+--- !u!54 &7473638909329927306
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839623426836133522}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &8257979677404303858
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839623426836133522}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.24871472, z: -0.006569177}
+--- !u!114 &5255270958456016188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839623426836133522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01f98db28979a478bba1fd64cb18904c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AutoGained: 1

--- a/Assets/Prefabs/BombDrop.prefab.meta
+++ b/Assets/Prefabs/BombDrop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 26870a131f9003d46a41c86c0e3675d1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ExpDrop.prefab
+++ b/Assets/Prefabs/ExpDrop.prefab
@@ -32,7 +32,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -81,7 +81,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: -3631159909506098806, guid: 86547782c0ca55f4098b1185db372acc, type: 3}
+  - {fileID: 2100000, guid: 1f91dd63938c6f740abfe84b0a06d07a, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/HPDrop.prefab
+++ b/Assets/Prefabs/HPDrop.prefab
@@ -1,0 +1,180 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &6536776522250513434
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.870895
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.9227386
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.11269
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 580d7e954bbff174794836248c2cc077, type: 2}
+    - target: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_Name
+      value: HPDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9163800017576692883}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1990574262304648099}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2799294612012860354}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3372932419374862179}
+  m_SourcePrefab: {fileID: 100100000, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+--- !u!1 &6230204848568521035 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 251889413fcfbe841a4d11ea37dfe4fe, type: 3}
+  m_PrefabInstance: {fileID: 6536776522250513434}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &9163800017576692883
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6230204848568521035}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.83950627
+  m_Height: 2.663424
+  m_Direction: 1
+  m_Center: {x: -0.000000029802322, y: 0.49946702, z: 0}
+--- !u!54 &1990574262304648099
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6230204848568521035}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &2799294612012860354
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6230204848568521035}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 2
+  m_Center: {x: -0.000000029802322, y: 0.49946702, z: 0}
+--- !u!114 &3372932419374862179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6230204848568521035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01f98db28979a478bba1fd64cb18904c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AutoGained: 1

--- a/Assets/Prefabs/HPDrop.prefab.meta
+++ b/Assets/Prefabs/HPDrop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1eb2d3175768efb4087d0e8cafe3b7ef
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/MagnetDrop.prefab
+++ b/Assets/Prefabs/MagnetDrop.prefab
@@ -1,0 +1,177 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &7904753944028935117
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274036480521014648, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_Name
+      value: MagnetDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4936489610023860970, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3605888089799322393}
+    - targetCorrespondingSourceObject: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 743835422194332375}
+    - targetCorrespondingSourceObject: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8706350320428782428}
+    - targetCorrespondingSourceObject: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7249370392410325496}
+  m_SourcePrefab: {fileID: 100100000, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+--- !u!1 &146950672145064975 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8050537342152234946, guid: 50e260f821baa56419af96b848301e5d, type: 3}
+  m_PrefabInstance: {fileID: 7904753944028935117}
+  m_PrefabAsset: {fileID: 0}
+--- !u!136 &3605888089799322393
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146950672145064975}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.9322048
+  m_Height: 1.9911377
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.06281698, z: -0.16763142}
+--- !u!54 &743835422194332375
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146950672145064975}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &8706350320428782428
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146950672145064975}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.06281698, z: -0.16763142}
+--- !u!114 &7249370392410325496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146950672145064975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01f98db28979a478bba1fd64cb18904c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AutoGained: 1

--- a/Assets/Prefabs/MagnetDrop.prefab.meta
+++ b/Assets/Prefabs/MagnetDrop.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bce6cc2b73d6530458273391cb3e46a2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -119,6 +119,63 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &9400051
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42.396145
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.814128
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.30869
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207658591406631976, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8839623426836133522, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
+      propertyPath: m_Name
+      value: BombDrop
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 26870a131f9003d46a41c86c0e3675d1, type: 3}
 --- !u!1 &92625523
 GameObject:
   m_ObjectHideFlags: 0
@@ -240,6 +297,95 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+--- !u!1001 &101010441
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.3495235
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 60.69958
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.3382438
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9410586
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 140.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553428363874128069, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3879627388438632007, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Normal
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].type
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[0].prefab
+      value: 
+      objectReference: {fileID: 1441539932403817440}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5775009654015994775, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].prefab
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3740c43e18f1228499fb09a8b051f107, type: 3}
 --- !u!1 &141118819
 GameObject:
   m_ObjectHideFlags: 0
@@ -628,6 +774,63 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1001 &762077959
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 146950672145064975, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_Name
+      value: MagnetDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 667028036419747509, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bce6cc2b73d6530458273391cb3e46a2, type: 3}
 --- !u!1 &766827632 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4310579322460622702, guid: 7677de9ad9d871d4c8cf9c862afa2b60, type: 3}
@@ -1147,6 +1350,95 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1333801205
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48.390884
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 65.65724
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.1188431
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99291307
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -193.651
+      objectReference: {fileID: 0}
+    - target: {fileID: 1072452914358767104, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6562850818961578959, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Flying
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].type
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[0].prefab
+      value: 
+      objectReference: {fileID: 1441539932403817440}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818279862347263861, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].prefab
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6e5f3a2399d8cd4d9645b45391ac1aa, type: 3}
 --- !u!1 &1420318121
 GameObject:
   m_ObjectHideFlags: 0
@@ -1213,6 +1505,95 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d1d2dc7d1d3caa41834e05bb5a377fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1449425655
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].type
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].type
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[0].prefab
+      value: 
+      objectReference: {fileID: 1441539932403817440}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[1].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[2].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3709207218791945279, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: dropPrefabs.Array.data[3].prefab
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 53.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.3495235
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 60.69958
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.13959214
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99020916
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -163.952
+      objectReference: {fileID: 0}
+    - target: {fileID: 5777423160311960130, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8565138331018671935, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Bomb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 042cb3b866ed2cb4ea3c690583808ed2, type: 3}
 --- !u!1 &1473219987 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4310579322460622702, guid: 7677de9ad9d871d4c8cf9c862afa2b60, type: 3}
@@ -1476,6 +1857,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3429552369996727388, guid: 7812c1c6f74ddba4b92038d843af8b49, type: 3}
+      propertyPath: m_Layer
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7240508943776955002, guid: 7812c1c6f74ddba4b92038d843af8b49, type: 3}
       propertyPath: m_Name
       value: Map
@@ -1529,6 +1914,63 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1001 &1687530748
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6230204848568521035, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_Name
+      value: HPDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.870895
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.9227386
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 71.11269
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718793264711306225, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eb2d3175768efb4087d0e8cafe3b7ef, type: 3}
 --- !u!114 &1751675720 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 627065009470660059, guid: 4a27a203a8aebbb47b495e30d66cc6f3, type: 3}
@@ -2505,6 +2947,68 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d1d2dc7d1d3caa41834e05bb5a377fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1441539932403817439
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1455748407966475154, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_Name
+      value: ExpDrop
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 44.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 70.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768889922610627570, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+--- !u!1 &1441539932403817440 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1455748407966475154, guid: 554d23adc85c94e629f15b15a7b20688, type: 3}
+  m_PrefabInstance: {fileID: 1441539932403817439}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2522,3 +3026,10 @@ SceneRoots:
   - {fileID: 2108323802}
   - {fileID: 2082697459}
   - {fileID: 585503649}
+  - {fileID: 101010441}
+  - {fileID: 1449425655}
+  - {fileID: 1333801205}
+  - {fileID: 1441539932403817439}
+  - {fileID: 9400051}
+  - {fileID: 1687530748}
+  - {fileID: 762077959}

--- a/Assets/Scripts/Drop/DropHelper.cs
+++ b/Assets/Scripts/Drop/DropHelper.cs
@@ -1,0 +1,15 @@
+using IMP.Core;
+using UnityEngine;
+
+public static class DropHelper
+{
+    public static DropType GetRandomDropType()
+    {
+        float rand = Random.Range(0f, 100f);
+
+        if (rand < 92.5f) return DropType.EXP;
+        if (rand < 95.0f) return DropType.HEAL;
+        if (rand < 97.5f) return DropType.MAGNET;
+        return DropType.BOMB;
+    }
+}

--- a/Assets/Scripts/Drop/DropHelper.cs.meta
+++ b/Assets/Scripts/Drop/DropHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60a5d4a83854c9d4e821e261c1cd7035

--- a/Assets/Scripts/Drop/DropItem.cs
+++ b/Assets/Scripts/Drop/DropItem.cs
@@ -6,7 +6,8 @@ namespace IMP.Core
     {
         EXP,
         MAGNET,
-        BOMB
+        BOMB,
+        HEAL
     }
 
     public class DropItem : MonoBehaviour
@@ -35,6 +36,10 @@ namespace IMP.Core
 
                 case DropType.BOMB:
                     m_ItemStrategy = new BombStrategy(this);
+                    break;
+
+                case DropType.HEAL:
+                    m_ItemStrategy = new HealStrategy(this);
                     break;
             }
         }

--- a/Assets/Scripts/Drop/HealStrategy.cs
+++ b/Assets/Scripts/Drop/HealStrategy.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace IMP.Core
+{
+    public class HealStrategy : IDropItemStrategy
+    {
+        private DropItem m_DropItem;
+        private int m_HealAmount = 30;
+
+        public HealStrategy(DropItem dropItem)
+        {
+            m_DropItem = dropItem;
+        }
+
+        public void Execute(Player player)
+        {
+            PlayerHealth health = player.GetComponent<PlayerHealth>();
+            if (health != null)
+            {
+                health.Heal(m_HealAmount);
+                GameObject.Destroy(m_DropItem.gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Drop/HealStrategy.cs.meta
+++ b/Assets/Scripts/Drop/HealStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8885b8a199b815242b604dddc86bc19e

--- a/Assets/Scripts/Monster/EnemyController.cs
+++ b/Assets/Scripts/Monster/EnemyController.cs
@@ -1,13 +1,15 @@
-/*
-
-Lee DongHun -> PlayerHealth
-
-*/
-
 using UnityEngine;
 using UnityEngine.UI;
+using IMP.Core;
 
 public enum EnemyType { Normal, Bomb, Flying }
+
+[System.Serializable]
+public class DropPrefabEntry
+{
+    public DropType type;
+    public GameObject prefab;
+}
 
 public class EnemyController : MonoBehaviour
 {
@@ -28,6 +30,8 @@ public class EnemyController : MonoBehaviour
 
     // donghun
     public int damage = 10;
+
+    [SerializeField] private DropPrefabEntry[] dropPrefabs;
 
     void Start()
     {
@@ -132,8 +136,38 @@ public class EnemyController : MonoBehaviour
             animator.SetTrigger("Death");
         }
 
-        Destroy(gameObject, 2f);
+        DropRandomItem();
 
+        Destroy(gameObject, 2f);
         DropHandler.OnEnemyDead?.Invoke(transform);
+    }
+
+    private void DropRandomItem()
+    {
+        int dropCount = Random.Range(3, 5);
+
+        for (int i = 0; i < dropCount; i++)
+        {
+            DropType dropType = DropHelper.GetRandomDropType();
+            GameObject selectedPrefab = null;
+
+            foreach (var entry in dropPrefabs)
+            {
+                if (entry.type == dropType)
+                {
+                    selectedPrefab = entry.prefab;
+                    break;
+                }
+            }
+
+            if (selectedPrefab == null) continue;
+
+            Vector3 dropPos = transform.position + Random.insideUnitSphere * 0.5f;
+            dropPos.y = transform.position.y;
+
+            GameObject drop = Instantiate(selectedPrefab, dropPos, Quaternion.identity);
+            DropItem dropItem = drop.GetComponent<DropItem>();
+            dropItem.SetStrategy(dropType);
+        }
     }
 }

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -50,6 +50,15 @@ public class PlayerHealth : MonoBehaviour
         }
     }
 
+    public void Heal(int amount)
+    {
+        if (isDead) return; // 사망 상태면 회복 불가
+
+        currentHP = Mathf.Min(currentHP + amount, maxHP); // 최대 체력 초과 방지
+
+        if (hpBar) hpBar.value = currentHP; // UI 갱신
+    } // CHAEWON
+
     IEnumerator IFrames()          // 잠깐 무적(핏박스 연속충돌 방지)
     {
         invincible = true;


### PR DESCRIPTION
- Added DropHelper with weighted probabilities (EXP: 92.5%, HEAL: 2.5%, MAGNET: 2.5%, BOMB: 2.5%)
- Modified EnemyController to drop 3~4 random items using DropPrefabEntry[]
- Created and assigned item prefabs: ExpDrop, HPDrop, MagnetDrop, BombDrop
- Implemented HealStrategy and updated PlayerHealth to support healing
- Changed EXP prefab color to green for better visibility